### PR TITLE
Tweaks a few things based on integrating with existing Rollout client

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,6 @@ gem install openfeature-rollout-provider
 
 ```ruby
 OpenFeature::SDK.configure do |config|
-  config.provider = OpenFeature::Rollout::Provider.build_client(::Rollout.new(Redis.new))
+  config.set_provider OpenFeature::Rollout::Provider.build_client(::Rollout.new(Redis.new))
 end
 ```

--- a/lib/openfeature/rollout/provider.rb
+++ b/lib/openfeature/rollout/provider.rb
@@ -51,7 +51,7 @@ module OpenFeature
         @rollout_client = rollout_client
       end
 
-      def fetch_boolean_value(flag_key:, default_value:, evaluation_context: nil)
+      def fetch_boolean_value(flag_key:, default_value: nil, evaluation_context: nil)
         res = @rollout_client.active?(flag_key, evaluation_context&.targeting_key)
 
         OpenFeature::SDK::Provider::ResolutionDetails.new(
@@ -64,23 +64,23 @@ module OpenFeature
         )
       end
 
-      def fetch_number_value(flag_key:, default_value:, evaluation_context: nil)
+      def fetch_number_value(flag_key:, default_value: nil, evaluation_context: nil)
         error_response(default_value, "TYPE_MISMATCH", "Rollout does not support numeric flag values")
       end
 
-      def fetch_integer_value(flag_key:, default_value:, evaluation_context: nil)
+      def fetch_integer_value(flag_key:, default_value: nil, evaluation_context: nil)
         error_response(default_value, "TYPE_MISMATCH", "Rollout does not support numeric flag values")
       end
 
-      def fetch_float_value(flag_key:, default_value:, evaluation_context: nil)
+      def fetch_float_value(flag_key:, default_value: nil, evaluation_context: nil)
         error_response(default_value, "TYPE_MISMATCH", "Rollout does not support numeric flag values")
       end
 
-      def fetch_string_value(flag_key:, default_value:, evaluation_context: nil)
+      def fetch_string_value(flag_key:, default_value: nil, evaluation_context: nil)
         error_response(default_value, "TYPE_MISMATCH", "Rollout does not support string flag values")
       end
 
-      def fetch_object_value(flag_key:, default_value:, evaluation_context: nil)
+      def fetch_object_value(flag_key:, default_value: nil, evaluation_context: nil)
         error_response(default_value, "TYPE_MISMATCH", "Rollout does not support object flag values")
       end
 

--- a/lib/openfeature/rollout/provider.rb
+++ b/lib/openfeature/rollout/provider.rb
@@ -52,7 +52,7 @@ module OpenFeature
       end
 
       def fetch_boolean_value(flag_key:, default_value: nil, evaluation_context: nil)
-        res = @rollout_client.active?(flag_key, evaluation_context&.targeting_key)
+        res = @rollout_client.active?(flag_key, evaluation_context)
 
         OpenFeature::SDK::Provider::ResolutionDetails.new(
           value: res,

--- a/lib/openfeature/rollout/provider.rb
+++ b/lib/openfeature/rollout/provider.rb
@@ -51,7 +51,7 @@ module OpenFeature
         @rollout_client = rollout_client
       end
 
-      def fetch_boolean_value(flag_key:, default_value: nil, evaluation_context: nil)
+      def fetch_boolean_value(flag_key:, default_value: false, evaluation_context: nil)
         res = @rollout_client.active?(flag_key, evaluation_context&.targeting_key)
 
         OpenFeature::SDK::Provider::ResolutionDetails.new(

--- a/lib/openfeature/rollout/provider.rb
+++ b/lib/openfeature/rollout/provider.rb
@@ -52,7 +52,7 @@ module OpenFeature
       end
 
       def fetch_boolean_value(flag_key:, default_value: nil, evaluation_context: nil)
-        res = @rollout_client.active?(flag_key, evaluation_context)
+        res = @rollout_client.active?(flag_key, evaluation_context&.targeting_key)
 
         OpenFeature::SDK::Provider::ResolutionDetails.new(
           value: res,


### PR DESCRIPTION
Makes a few small changes based on implementing this provider with an existing Rollout implementation:

1. [4ce9fa2](https://github.com/bryanalves/openfeature-rollout-provider/pull/1/commits/4ce9fa2d75cc5613c71cced362d8976664c43780) —> Update the `README.md` to use `set_provider` instead of `provider=`. This is based on the `OpenFeature::SDK::Configuration` class's [`set_provider`](https://github.com/open-feature/ruby-sdk/blob/main/lib/open_feature/sdk/configuration.rb#L30-L37) method.
2. [ea0f7ad](https://github.com/bryanalves/openfeature-rollout-provider/pull/1/commits/ea0f7ad57df006cb579b115fbbb861d2de88d519) —> Since Rollout's Ruby SDK doesn't accept a `default_value` argument (and thus we aren't passing one when we [invoke the client](https://github.com/bryanalves/openfeature-rollout-provider/blob/master/lib/openfeature/rollout/provider.rb#L55)) I _thiiink_ it's safe to pass a default `nil` to that keyword argument here in the provider, which will save the caller from having to pass `default_value: nil` at all its call points.
3. [09e05ae](https://github.com/bryanalves/openfeature-rollout-provider/pull/1/commits/09e05aed0949ca32b90d930a3baa725a58414976) —> Eliminates the invocation of `&.targeting_key` on the object passed as the `evaluation_context`. The Rollout Ruby client expects the second argument to its [`active?`](https://github.com/fetlife/rollout/blob/master/lib/rollout.rb#L108) method to represent the evaluation context for the feature in question, and it expects it in the form of a `user` object (though for all intents and purposes it doesn't actually _need_ to represent a user in the parent architecture). It expects to be able to operate on that object itself to [get the ID it needs](https://github.com/fetlife/rollout/blob/master/lib/rollout/feature.rb#L52-L61) to provide a flag context. Thus, in the case of Rollout, removing the invocation of `&.targeting_key` allows for passing the context object through to the client without first needing to wrap it in an [`OpenFeature::SDK::EvaluationContext.new`](https://github.com/open-feature/ruby-sdk/blob/27b2dab4fed0b348d0575c0909d4beeea376b27d/lib/open_feature/sdk/evaluation_context.rb#L12-L14).

Example:
```ruby
OpenFeature::SDK.provider.fetch_boolean_flag(flag_key: :flag_name, evaluation_context: current_user)
```
...instead of...
```ruby
context_object = OpenFeature::SDK::EvaluationContext.new(targeting_key: current_user.id)
OpenFeature::SDK.provider.fetch_boolean_flag(flag_key: :flag_name, evaluation_context: context_object)
```